### PR TITLE
Allow using pretrained embeddings

### DIFF
--- a/ProgressiveTransformersSLP/Configs/Base.yaml
+++ b/ProgressiveTransformersSLP/Configs/Base.yaml
@@ -3,9 +3,9 @@ data:
     trg: "skels" # Target - 3D body co-ordinates (skels)
     files: "files" # Filenames for each sequence
 
-    train: "./Data/tmp/train"
-    dev: "./Data/tmp/dev"
-    test: "./Data/tmp/test"
+    train: "./slp/ProgressiveTransformersSLP/Data/tmp/train"
+    dev: "./slp/ProgressiveTransformersSLP/Data/tmp/dev"
+    test: "./slp/ProgressiveTransformersSLP/Data/tmp/test"
 
     max_sent_length: 300 # Max Sentence Length
     skip_frames: 1 # Skip frames in the data, to reduce the data input size
@@ -50,9 +50,10 @@ model:
         num_layers: 2 # Number of layers
         num_heads: 4 # Number of Heads
         embeddings:
-            embedding_dim: 512 # Embedding Dimension
+            model: "bert"  # Pretrained embeddings: ("none", "bert")
+            embedding_dim: 768 # Embedding Dimension
             dropout: 0.0 # Embedding Dropout
-        hidden_size: 512 # Hidden Size Dimension
+        hidden_size: 768 # Hidden Size Dimension
         ff_size: 2048 # Feed-forward dimension (4 x hidden_size)
         dropout: 0.0 # Encoder Dropout
     decoder: # Model Decoder
@@ -60,8 +61,8 @@ model:
         num_layers: 2 # Number of layers
         num_heads: 4 # Number of Heads
         embeddings:
-            embedding_dim: 512 # Embedding Dimension
+            embedding_dim: 768 # Embedding Dimension
             dropout: 0.0 # Embedding Dropout
-        hidden_size: 512 # Hidden Size Dimension
+        hidden_size: 768 # Hidden Size Dimension
         ff_size: 2048 # Feed-forward dimension (4 x hidden_size)
         dropout: 0.0 # Decoder Dropout

--- a/ProgressiveTransformersSLP/batch.py
+++ b/ProgressiveTransformersSLP/batch.py
@@ -7,7 +7,7 @@ Implementation of a mini-batch.
 import torch
 import torch.nn.functional as F
 
-from constants import TARGET_PAD
+import constants
 
 class Batch:
     """Object for holding a batch of data with mask during training.
@@ -37,7 +37,7 @@ class Batch:
 
         self.file_paths = torch_batch.file_paths
         self.use_cuda = model.use_cuda
-        self.target_pad = TARGET_PAD
+        self.target_pad = constants.TARGET_PAD
         # Just Count
         self.just_count_in = model.just_count_in
         # Future Prediction

--- a/ProgressiveTransformersSLP/constants.py
+++ b/ProgressiveTransformersSLP/constants.py
@@ -3,11 +3,26 @@
 Defining global constants
 """
 
-UNK_TOKEN = '<unk>'
-PAD_TOKEN = '<pad>'
-BOS_TOKEN = '<s>'
-EOS_TOKEN = '</s>'
+# Declare variables
+model, UNK_TOKEN, PAD_TOKEN, BOS_TOKEN, EOS_TOKEN, TARGET_PAD, DEFAULT_UNK_ID = [None]*7
 
-TARGET_PAD = 0.0
+special_tokens = {
+    "none": ('<unk>', '<pad>', '<s>', '</s>'),
+    "bert": ('[UNK]', '[PAD]', '[CLS]', '[SEP]')
+}
 
-DEFAULT_UNK_ID = lambda: 0
+unk_token_id = {
+    "none": 0,
+    "bert": 2
+}
+
+
+def initialize_constants(cfg: dict):
+    global model, UNK_TOKEN, PAD_TOKEN, BOS_TOKEN, EOS_TOKEN, TARGET_PAD, DEFAULT_UNK_ID
+    model = cfg["model"]["encoder"]["embeddings"]["model"]
+    if model not in ("none", "bert"):
+        raise ValueError(f"embeddings from model {model} not supported")
+
+    UNK_TOKEN, PAD_TOKEN, BOS_TOKEN, EOS_TOKEN = special_tokens[model]
+    TARGET_PAD = 0.0
+    DEFAULT_UNK_ID = lambda: unk_token_id[model]

--- a/ProgressiveTransformersSLP/embeddings.py
+++ b/ProgressiveTransformersSLP/embeddings.py
@@ -46,8 +46,10 @@ class Embeddings(nn.Module):
 
     # pylint: disable=unused-argument
     def __init__(self,
+                 model: str,
                  embedding_dim: int = 64,
                  scale: bool = False,
+                 pretrained_embed: Tensor = None,
                  vocab_size: int = 0,
                  padding_idx: int = 1,
                  freeze: bool = False,
@@ -64,14 +66,20 @@ class Embeddings(nn.Module):
         """
         super(Embeddings, self).__init__()
 
+        self.model = model
         self.embedding_dim = embedding_dim
         self.scale = scale
         self.vocab_size = vocab_size
-        self.lut = nn.Embedding(vocab_size, self.embedding_dim,
-                                padding_idx=padding_idx)
-
-        if freeze:
-            freeze_params(self)
+        if model == "none" or pretrained_embed is None:
+            # Train from scratch
+            self.lut = nn.Embedding(vocab_size, self.embedding_dim,
+                                    padding_idx=padding_idx)
+            if freeze:
+                freeze_params(self)
+        elif model == "bert":
+            # Use pretrained embeddings
+            self.lut = nn.Embedding.from_pretrained(
+                pretrained_embed, freeze=freeze, padding_idx=padding_idx)
 
     # pylint: disable=arguments-differ
     def forward(self, x: Tensor) -> Tensor:

--- a/ProgressiveTransformersSLP/prediction.py
+++ b/ProgressiveTransformersSLP/prediction.py
@@ -10,7 +10,7 @@ from helpers import bpe_postprocess, load_config, get_latest_checkpoint, \
 from model import build_model, Model
 from batch import Batch
 from data import load_data, make_data_iter
-from constants import UNK_TOKEN, PAD_TOKEN, EOS_TOKEN
+from constants import PAD_TOKEN
 
 # Validate epoch given a dataset
 def validate_on_data(model: Model,

--- a/ProgressiveTransformersSLP/transformer_layers.py
+++ b/ProgressiveTransformersSLP/transformer_layers.py
@@ -6,7 +6,7 @@ import torch.nn as nn
 from torch import Tensor
 import numpy as np
 import torch.nn.functional as F
-from constants import TARGET_PAD
+import constants
 
 
 # pylint: disable=arguments-differ
@@ -29,7 +29,7 @@ class MultiHeadedAttention(nn.Module):
         self.output_layer = nn.Linear(size, size)
         self.softmax = nn.Softmax(dim=-1)
         self.dropout = nn.Dropout(dropout)
-        self.target_pad = TARGET_PAD
+        self.target_pad = constants.TARGET_PAD
 
     def forward(self, k: Tensor, v: Tensor, q: Tensor, mask: Tensor = None, padding_mask: Tensor = None):
 


### PR DESCRIPTION
This PR modifies the original ProgressiveTransformersSLP code in order to allow the use of pretrained embeddings (for now BERT). The goal is to determine whether the use of pretrained embeddings improves training results or not.